### PR TITLE
Support windows

### DIFF
--- a/pp.go
+++ b/pp.go
@@ -3,19 +3,26 @@ package pp
 import (
 	"errors"
 	"fmt"
+	"github.com/mattn/go-colorable"
 	"io"
 )
 
+var out io.Writer
+
+func init() {
+	out = colorable.NewColorableStdout()
+}
+
 func Print(a ...interface{}) (n int, err error) {
-	return fmt.Print(formatAll(a)...)
+	return fmt.Fprint(out, formatAll(a)...)
 }
 
 func Printf(format string, a ...interface{}) (n int, err error) {
-	return fmt.Printf(format, formatAll(a)...)
+	return fmt.Fprintf(out, format, formatAll(a)...)
 }
 
 func Println(a ...interface{}) (n int, err error) {
-	return fmt.Println(formatAll(a)...)
+	return fmt.Fprintln(out, formatAll(a)...)
 }
 
 func Sprint(a ...interface{}) string {


### PR DESCRIPTION
Use [colorable](https://github.com/mattn/go-colorable).NewColorableStdout() for Print, Printf, Println's output to support windows.
Thanks @mattn!

![](http://i.gyazo.com/ab791997a980f1ab3ee2a01586efdce6.png)
