### PR TITLE
Handle circular structures

### DIFF
--- a/printer_test.go
+++ b/printer_test.go
@@ -38,6 +38,16 @@ type HogeHoge struct {
 	A     interface{}
 }
 
+type Circular struct {
+	C *Circular
+}
+
+var c Circular = Circular{}
+
+func init() {
+	c.C = &c
+}
+
 var (
 	testCases = []testCase{
 		{nil, boldCyan("nil")},
@@ -80,6 +90,7 @@ var (
 		FooPri{Public: "hello", private: "world"},
 		new(regexp.Regexp),
 		unsafe.Pointer(new(regexp.Regexp)),
+		&c,
 	}
 )
 


### PR DESCRIPTION
When pp is given a circular structure, it enters an infinite recursion.

This pull request changes pp to remember where it visited and not to visit there again to avoid infinite recursion.