### PR TITLE
Color escaped characters inside strings

### DIFF
--- a/printer_test.go
+++ b/printer_test.go
@@ -97,6 +97,7 @@ var (
 				}
 			`,
 		},
+		{"日本\t語\x00", `[red][bold]"[reset][red]日本[reset][magenta][bold]\t[reset][red]語[reset][magenta][bold]\x00[reset][red][bold]"`},
 	}
 
 	arr [3]int
@@ -116,6 +117,7 @@ var (
 		FooPri{Public: "hello", private: "world"},
 		new(regexp.Regexp),
 		unsafe.Pointer(new(regexp.Regexp)),
+		"日本\t語\n\000\U00101234a",
 	}
 )
 


### PR DESCRIPTION
Color escapes in strings such as "\t" for readability.
The coloring is taken from pry (bold magenta).

![2015-02-14 20 48 21](https://cloud.githubusercontent.com/assets/8465/6199513/9c9a21f4-b48b-11e4-8c91-9800f82a7549.png)
