### PR TITLE
escape sequences to pipe

### DIFF
--- a/color.go
+++ b/color.go
@@ -6,6 +6,10 @@ import (
 )
 
 var (
+	// If you set false to this variable, you can use pretty formatter
+	// without coloring.
+	ColoringEnabled = true
+
 	codeByColor = map[string]int{
 		"black":   30,
 		"red":     31,
@@ -42,10 +46,16 @@ func colorize(text, color string) string {
 func colorizer(color string) func(string) string {
 	if code, ok := codeByColor[color]; ok {
 		return func(text string) string {
+			if !ColoringEnabled {
+				return text
+			}
 			return fmt.Sprintf("\033[%dm%s\033[0m", code, text)
 		}
 	} else if code, ok := codeByColor[strings.ToLower(color)]; ok {
 		return func(text string) string {
+			if !ColoringEnabled {
+				return text
+			}
 			return fmt.Sprintf("\033[%dm\033[1m%s\033[0m", code, text)
 		}
 	} else {

--- a/color_test.go
+++ b/color_test.go
@@ -10,7 +10,8 @@ type colorTest struct {
 }
 
 var (
-	expects = []colorTest{
+	testText = "palette"
+	expects  = []colorTest{
 		{"black", "\x1b[30mpalette\x1b[0m"},
 		{"red", "\x1b[31mpalette\x1b[0m"},
 		{"green", "\x1b[32mpalette\x1b[0m"},
@@ -51,10 +52,16 @@ func TestColorize(t *testing.T) {
 	t.Logf(boldMagenta("Magenta"))
 	t.Logf(boldCyan("Cyan"))
 	t.Logf(boldWhite("White"))
+
+	ColoringEnabled = false
+	for _, test := range expects {
+		expect(t, test.input, testText)
+	}
+	ColoringEnabled = true
 }
 
 func expect(t *testing.T, input, result string) {
-	actual := colorize("palette", input)
+	actual := colorize(testText, input)
 	if actual != result {
 		t.Errorf("Expected: %#v, Actual: %#v", result, actual)
 	} else {

--- a/pp.go
+++ b/pp.go
@@ -10,11 +10,14 @@ import (
 	"github.com/mattn/go-colorable"
 )
 
-var out, defaultOut io.Writer
-var outLock sync.Mutex
+var (
+	out     io.Writer
+	outLock sync.Mutex
+
+	defaultOut = colorable.NewColorableStdout()
+)
 
 func init() {
-	defaultOut = colorable.NewColorableStdout()
 	out = defaultOut
 }
 

--- a/printer.go
+++ b/printer.go
@@ -205,6 +205,7 @@ func (p *printer) printSlice() {
 
 	if p.value.Kind() == reflect.Slice {
 		if p.visited[p.value.Pointer()] {
+			// Stop travarsing cyclic reference
 			p.printf("%s{...}", p.typeString())
 			return
 		}


### PR DESCRIPTION
pp write escape sequences into output stream. when the output is not a terminal, i wonder how pp should do work.

* remove escape sequences?
* same as terminal?

I'm thinking pp SHOULD NOT have behavior against whether stdout is terminal or not.
So, I want to you to provide A WAY to remove escape sequence for pp, but formatting is enabled.

How do you think?

