### PR TITLE
Suppress panic caused by Float values

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -301,6 +301,8 @@ func (p *printer) raw() string {
 		return fmt.Sprintf("%#v", p.value.Int())
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return fmt.Sprintf("%#v", p.value.Uint())
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%#v", p.value.Float())
 	case reflect.Complex64, reflect.Complex128:
 		return fmt.Sprintf("%#v", p.value.Complex())
 	default:


### PR DESCRIPTION
Float32 and Float64 values cause a panic when a fields is not exported. This patch fixes the problem.