### PR TITLE
check whether reflect.Value can call `Interface()`

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -189,6 +189,11 @@ func (p *printer) printStruct() {
 }
 
 func (p *printer) printTime() {
+	if !p.value.CanInterface() {
+		p.printf("(cannot print unexported field)")
+		return
+	}
+
 	tm := p.value.Interface().(time.Time)
 	p.printf(
 		"%s-%s-%s %s:%s:%s %s",


### PR DESCRIPTION
A struct that contains unexported `time.Time` field such as

```go
package sample

type Comment struct {
    text string
    tm time.Time
}
```

cannot be pretty printed by panicking as follows:

```
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
```

when it's passed to `pp.Printf()` in `main` package.

I added a check whether `p.value` can call `Interface()`.
I'm not sure it is a good solution to display a comment (`"cannot print unexported field"`) so this PR is just a suggestion.