### PR TITLE
Update the map printer to properly print maps.

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -19,6 +19,8 @@ var (
 	// If the length of array or slice is larger than this,
 	// the buffer will be shorten as {...}.
 	BufferFoldThreshold = 1024
+	// PrintMapTypes when set to true will have map types will always appended to maps.
+	PrintMapTypes = true
 )
 
 func format(object interface{}) string {
@@ -155,7 +157,11 @@ func (p *printer) printMap() {
 	}
 	p.visited[p.value.Pointer()] = true
 
-	p.printf("%s{", p.typeString())
+	if PrintMapTypes {
+		p.printf("%s{", p.typeString())
+	} else {
+		p.println("{")
+	}
 	p.indented(func() {
 		keys := p.value.MapKeys()
 		for i := 0; i < p.value.Len(); i++ {

--- a/printer.go
+++ b/printer.go
@@ -155,7 +155,7 @@ func (p *printer) printMap() {
 	}
 	p.visited[p.value.Pointer()] = true
 
-	p.println("{")
+	p.printf("%s{", p.typeString())
 	p.indented(func() {
 		keys := p.value.MapKeys()
 		for i := 0; i < p.value.Len(); i++ {


### PR DESCRIPTION
This used to print maps without the type when we were looking to use this for code generation. So

```
values:
    foo: true

```

would print as 
```
{
foo: true
}
```

Now it should print as a typed map (or typed as interface{}) e.g.
```
map[string]bool{
    foo: true,
}
```