### PR TITLE
Fix newline of map type

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -158,7 +158,7 @@ func (p *printer) printMap() {
 	p.visited[p.value.Pointer()] = true
 
 	if PrintMapTypes {
-		p.printf("%s{", p.typeString())
+		p.printf("%s{\n", p.typeString())
 	} else {
 		p.println("{")
 	}

--- a/printer_test.go
+++ b/printer_test.go
@@ -175,6 +175,16 @@ var (
 			}
 			`,
 		},
+		{
+			map[string]interface{}{"foo": 10, "bar": map[int]int{20: 30}}, `
+			[green]map[string]interface {}[reset]{
+			  [red][bold]"[reset][red]foo[reset][red][bold]"[reset]: [blue][bold]10[reset],
+			  [red][bold]"[reset][red]bar[reset][red][bold]"[reset]: [green]map[int]int[reset]{
+			    [blue][bold]20[reset]: [blue][bold]30[reset],
+			  },
+			}
+			`,
+		},
 	}
 
 	arr [3]int


### PR DESCRIPTION
The bug is introduced in #25, I'm not sure why the weird behavior is not found for years.

|Before|After|
|--|--|
|<img width="481" alt="screen shot 2019-03-03 at 23 30 52" src="https://user-images.githubusercontent.com/375258/53696676-ebe9ab80-3e0c-11e9-83e6-89dc87539398.png">|<img width="493" alt="screen shot 2019-03-03 at 23 31 18" src="https://user-images.githubusercontent.com/375258/53696680-f0ae5f80-3e0c-11e9-8716-0f2cd7f9e856.png">|
