### PR TITLE
Allow own instances of pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ pp.Fprintf()
 // ...
 ```
 
+You can also create own instances that do not interfer with the default printer
+```go
+mypp := pp.New()
+mypp.SetOutput(os.Stderr)
+mypp.Println()
+// ...
+```
+
 API doc is available at: http://godoc.org/github.com/k0kubun/pp
 
 ### Custom colors

--- a/pp.go
+++ b/pp.go
@@ -12,88 +12,216 @@ import (
 )
 
 var (
-	out     io.Writer
-	outLock sync.Mutex
-
-	defaultOut = colorable.NewColorableStdout()
-
-	currentScheme ColorScheme
-	// WithLineInfo add file name and line information to output
-	// call this function with care, because getting stack has performance penalty
-	WithLineInfo = false
+	defaultOut           = colorable.NewColorableStdout()
+	defaultWithLineInfo  = false
+	defaultPrettyPrinter = &PrettyPrinter{}
 )
 
 func init() {
-	out = defaultOut
-	currentScheme = defaultScheme
+	defaultPrettyPrinter.out = defaultOut
+	defaultPrettyPrinter.currentScheme = defaultScheme
+	defaultPrettyPrinter.WithLineInfo = defaultWithLineInfo
+}
+
+type PrettyPrinter struct {
+	out           io.Writer
+	currentScheme ColorScheme
+	// WithLineInfo add file name and line information to output
+	// call this function with care, because getting stack has performance penalty
+	WithLineInfo bool
+	outLock      sync.Mutex
+}
+
+// New creates a new PrettyPrinter that can be used to pretty print values
+func New() *PrettyPrinter {
+	return &PrettyPrinter{
+		out:           defaultOut,
+		currentScheme: defaultScheme,
+		WithLineInfo:  defaultWithLineInfo,
+	}
 }
 
 // Print prints given arguments.
-func Print(a ...interface{}) (n int, err error) {
-	return fmt.Fprint(out, formatAll(a)...)
+func (pp *PrettyPrinter) Print(a ...interface{}) (n int, err error) {
+	return fmt.Fprint(pp.out, pp.formatAll(a)...)
 }
 
 // Printf prints a given format.
-func Printf(format string, a ...interface{}) (n int, err error) {
-	return fmt.Fprintf(out, format, formatAll(a)...)
+func (pp *PrettyPrinter) Printf(format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(pp.out, format, pp.formatAll(a)...)
 }
 
 // Println prints given arguments with newline.
-func Println(a ...interface{}) (n int, err error) {
-	return fmt.Fprintln(out, formatAll(a)...)
+func (pp *PrettyPrinter) Println(a ...interface{}) (n int, err error) {
+	return fmt.Fprintln(pp.out, pp.formatAll(a)...)
 }
 
 // Sprint formats given arguemnts and returns the result as string.
-func Sprint(a ...interface{}) string {
-	return fmt.Sprint(formatAll(a)...)
+func (pp *PrettyPrinter) Sprint(a ...interface{}) string {
+	return fmt.Sprint(pp.formatAll(a)...)
 }
 
 // Sprintf formats with pretty print and returns the result as string.
-func Sprintf(format string, a ...interface{}) string {
-	return fmt.Sprintf(format, formatAll(a)...)
+func (pp *PrettyPrinter) Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, pp.formatAll(a)...)
 }
 
 // Sprintln formats given arguemnts with newline and returns the result as string.
-func Sprintln(a ...interface{}) string {
-	return fmt.Sprintln(formatAll(a)...)
+func (pp *PrettyPrinter) Sprintln(a ...interface{}) string {
+	return fmt.Sprintln(pp.formatAll(a)...)
 }
 
 // Fprint prints given arguments to a given writer.
-func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
-	return fmt.Fprint(w, formatAll(a)...)
+func (pp *PrettyPrinter) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+	return fmt.Fprint(w, pp.formatAll(a)...)
 }
 
 // Fprintf prints format to a given writer.
-func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
-	return fmt.Fprintf(w, format, formatAll(a)...)
+func (pp *PrettyPrinter) Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(w, format, pp.formatAll(a)...)
 }
 
 // Fprintln prints given arguments to a given writer with newline.
-func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
-	return fmt.Fprintln(w, formatAll(a)...)
+func (pp *PrettyPrinter) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+	return fmt.Fprintln(w, pp.formatAll(a)...)
 }
 
 // Errorf formats given arguments and returns it as error type.
-func Errorf(format string, a ...interface{}) error {
-	return errors.New(Sprintf(format, a...))
+func (pp *PrettyPrinter) Errorf(format string, a ...interface{}) error {
+	return errors.New(pp.Sprintf(format, a...))
 }
 
 // Fatal prints given arguments and finishes execution with exit status 1.
-func Fatal(a ...interface{}) {
-	fmt.Fprint(out, formatAll(a)...)
+func (pp *PrettyPrinter) Fatal(a ...interface{}) {
+	fmt.Fprint(pp.out, pp.formatAll(a)...)
 	os.Exit(1)
 }
 
 // Fatalf prints a given format and finishes execution with exit status 1.
-func Fatalf(format string, a ...interface{}) {
-	fmt.Fprintf(out, format, formatAll(a)...)
+func (pp *PrettyPrinter) Fatalf(format string, a ...interface{}) {
+	fmt.Fprintf(pp.out, format, pp.formatAll(a)...)
 	os.Exit(1)
 }
 
 // Fatalln prints given arguments with newline and finishes execution with exit status 1.
-func Fatalln(a ...interface{}) {
-	fmt.Fprintln(out, formatAll(a)...)
+func (pp *PrettyPrinter) Fatalln(a ...interface{}) {
+	fmt.Fprintln(pp.out, pp.formatAll(a)...)
 	os.Exit(1)
+}
+
+// SetOutput sets pp's output
+func (pp *PrettyPrinter) SetOutput(o io.Writer) {
+	pp.outLock.Lock()
+	pp.out = o
+	pp.outLock.Unlock()
+}
+
+// GetOutput returns pp's output.
+func (pp *PrettyPrinter) GetOutput() io.Writer {
+	return pp.out
+}
+
+// ResetOutput sets pp's output back to the default output
+func (pp *PrettyPrinter) ResetOutput() {
+	pp.outLock.Lock()
+	pp.out = defaultOut
+	pp.outLock.Unlock()
+}
+
+// SetColorScheme takes a colorscheme used by all future Print calls.
+func (pp *PrettyPrinter) SetColorScheme(scheme ColorScheme) {
+	scheme.fixColors()
+	pp.currentScheme = scheme
+}
+
+// ResetColorScheme resets colorscheme to default.
+func (pp *PrettyPrinter) ResetColorScheme() {
+	pp.currentScheme = defaultScheme
+}
+
+func (pp *PrettyPrinter) formatAll(objects []interface{}) []interface{} {
+	results := []interface{}{}
+
+	// fix for backwards capability
+	withLineInfo := pp.WithLineInfo
+	if pp == defaultPrettyPrinter {
+		withLineInfo = WithLineInfo
+	}
+
+	if withLineInfo {
+		_, fn, line, _ := runtime.Caller(2) // 2 because current Caller is pp itself
+		results = append(results, fmt.Sprintf("%s:%d\n", fn, line))
+	}
+
+	for _, object := range objects {
+		results = append(results, pp.format(object))
+	}
+	return results
+}
+
+// Print prints given arguments.
+func Print(a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Print(a...)
+}
+
+// Printf prints a given format.
+func Printf(format string, a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Printf(format, a...)
+}
+
+// Println prints given arguments with newline.
+func Println(a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Println(a...)
+}
+
+// Sprint formats given arguemnts and returns the result as string.
+func Sprint(a ...interface{}) string {
+	return defaultPrettyPrinter.Sprint(a...)
+}
+
+// Sprintf formats with pretty print and returns the result as string.
+func Sprintf(format string, a ...interface{}) string {
+	return defaultPrettyPrinter.Sprintf(format, a...)
+}
+
+// Sprintln formats given arguemnts with newline and returns the result as string.
+func Sprintln(a ...interface{}) string {
+	return defaultPrettyPrinter.Sprintln(a...)
+}
+
+// Fprint prints given arguments to a given writer.
+func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Fprint(w, a...)
+}
+
+// Fprintf prints format to a given writer.
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Fprintf(w, format, a...)
+}
+
+// Fprintln prints given arguments to a given writer with newline.
+func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+	return defaultPrettyPrinter.Fprintln(w, a...)
+}
+
+// Errorf formats given arguments and returns it as error type.
+func Errorf(format string, a ...interface{}) error {
+	return defaultPrettyPrinter.Errorf(format, a...)
+}
+
+// Fatal prints given arguments and finishes execution with exit status 1.
+func Fatal(a ...interface{}) {
+	defaultPrettyPrinter.Fatal(a...)
+}
+
+// Fatalf prints a given format and finishes execution with exit status 1.
+func Fatalf(format string, a ...interface{}) {
+	defaultPrettyPrinter.Fatalf(format, a...)
+}
+
+// Fatalln prints given arguments with newline and finishes execution with exit status 1.
+func Fatalln(a ...interface{}) {
+	defaultPrettyPrinter.Fatalln(a...)
 }
 
 // Change Print* functions' output to a given writer.
@@ -105,44 +233,29 @@ func Fatalln(a ...interface{}) {
 //		}
 //	}
 func SetDefaultOutput(o io.Writer) {
-	outLock.Lock()
-	out = o
-	outLock.Unlock()
+	defaultPrettyPrinter.SetOutput(o)
 }
 
-// GetDefaultOutput returns pp's default output.
+// GetOutput returns pp's default output.
 func GetDefaultOutput() io.Writer {
-	return out
+	return defaultPrettyPrinter.GetOutput()
 }
 
 // Change Print* functions' output to default one.
 func ResetDefaultOutput() {
-	outLock.Lock()
-	out = defaultOut
-	outLock.Unlock()
+	defaultPrettyPrinter.ResetOutput()
 }
 
 // SetColorScheme takes a colorscheme used by all future Print calls.
 func SetColorScheme(scheme ColorScheme) {
-	scheme.fixColors()
-	currentScheme = scheme
+	defaultPrettyPrinter.SetColorScheme(scheme)
 }
 
 // ResetColorScheme resets colorscheme to default.
 func ResetColorScheme() {
-	currentScheme = defaultScheme
+	defaultPrettyPrinter.ResetColorScheme()
 }
 
-func formatAll(objects []interface{}) []interface{} {
-	results := []interface{}{}
-
-	if WithLineInfo {
-		_, fn, line, _ := runtime.Caller(2) // 2 because current Caller is pp itself
-		results = append(results, fmt.Sprintf("%s:%d\n", fn, line))
-	}
-
-	for _, object := range objects {
-		results = append(results, format(object))
-	}
-	return results
-}
+// WithLineInfo add file name and line information to output
+// call this function with care, because getting stack has performance penalty
+var WithLineInfo bool

--- a/pp_test.go
+++ b/pp_test.go
@@ -10,7 +10,7 @@ func TestDefaultOutput(t *testing.T) {
 	init := GetDefaultOutput()
 	SetDefaultOutput(testOutput)
 	if GetDefaultOutput() != testOutput {
-		t.Errorf("failed to SetDefaultOutput")
+		t.Errorf("failed to SetOutput")
 	}
 	if len(testOutput.String()) != 0 {
 		t.Errorf("testOutput should be initialized")
@@ -31,7 +31,44 @@ func TestDefaultOutput(t *testing.T) {
 func TestColorScheme(t *testing.T) {
 	SetColorScheme(ColorScheme{})
 
-	if currentScheme.FieldName == 0 {
+	if defaultPrettyPrinter.currentScheme.FieldName == 0 {
 		t.FailNow()
 	}
+}
+
+func TestWithLineInfo(t *testing.T) {
+	outputWithoutLineInfo := new(bytes.Buffer)
+	SetDefaultOutput(outputWithoutLineInfo)
+	Print("abcde")
+
+	outputWithLineInfo := new(bytes.Buffer)
+	SetDefaultOutput(outputWithLineInfo)
+	WithLineInfo = true
+	Print("abcde")
+
+	ResetDefaultOutput()
+
+	if bytes.Equal(outputWithLineInfo.Bytes(), outputWithoutLineInfo.Bytes()) {
+		t.Errorf("outputWithLineInfo should not have the same contents than outputWithoutLineInfo")
+	}
+}
+
+func TestWithLineInfoBackwardsCompatible(t *testing.T) {
+	// Test that the global accessible field `WithLineInfo` does not mutate other instances
+
+	outputWithLineInfo := new(bytes.Buffer)
+	SetDefaultOutput(outputWithLineInfo)
+	WithLineInfo = true
+	Print("abcde")
+
+	outputWithoutLineInfo := new(bytes.Buffer)
+	pp := New()
+	pp.SetOutput(outputWithoutLineInfo)
+	pp.Print("abcde")
+
+	if bytes.Equal(outputWithLineInfo.Bytes(), outputWithoutLineInfo.Bytes()) {
+		t.Errorf("outputWithLineInfo should not have the same contents than outputWithoutLineInfo")
+	}
+
+	ResetDefaultOutput()
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -215,7 +215,7 @@ var (
 
 func TestFormat(t *testing.T) {
 	for _, test := range testCases {
-		actual := fmt.Sprintf("%s", format(test.object))
+		actual := fmt.Sprintf("%s", defaultPrettyPrinter.format(test.object))
 
 		trimmed := strings.Replace(test.expect, "\t", "", -1)
 		trimmed = strings.TrimPrefix(trimmed, "\n")
@@ -230,7 +230,7 @@ func TestFormat(t *testing.T) {
 	}
 
 	for _, object := range checkCases {
-		actual := fmt.Sprintf("%s", format(object))
+		actual := fmt.Sprintf("%s", defaultPrettyPrinter.format(object))
 		logResult(t, object, actual)
 	}
 }


### PR DESCRIPTION
This PR contains the implementation of the struct `PrettyPrinter`.  
With the new `New()` function, developers can create new instances that does not interfer with the _global_ printer.

## Motivation
* Testability of PP
* Multiple PP instances with different `ColorSchemas` and different outputs

## Notice
This PR does not break backwards compatibility