### PR TITLE
Add Struct Tag Support for Printing

### DIFF
--- a/pp_test.go
+++ b/pp_test.go
@@ -2,6 +2,7 @@ package pp
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -71,4 +72,91 @@ func TestWithLineInfoBackwardsCompatible(t *testing.T) {
 	}
 
 	ResetDefaultOutput()
+}
+
+func TestStructPrintingWithTags(t *testing.T) {
+	type Foo struct {
+		IgnoreMe     interface{} `pp:"-"`
+		ChangeMyName string      `pp:"NewName"`
+		OmitIfEmpty  string      `pp:",omitempty"`
+		Full         string      `pp:"full,omitempty"`
+	}
+
+	testCases := []struct {
+		name               string
+		foo                Foo
+		omitIfEmptyOmitted bool
+		fullOmitted        bool
+	}{
+		{
+			name: "all set",
+			foo: Foo{
+				IgnoreMe:     "i'm a secret",
+				ChangeMyName: "i'm an alias",
+				OmitIfEmpty:  "i'm not empty",
+				Full:         "hello",
+			},
+			omitIfEmptyOmitted: false,
+			fullOmitted:        false,
+		},
+		{
+			name: "omit if empty not set",
+			foo: Foo{
+				IgnoreMe:     "i'm a secret",
+				ChangeMyName: "i'm an alias",
+				OmitIfEmpty:  "",
+				Full:         "hello",
+			},
+			omitIfEmptyOmitted: true,
+			fullOmitted:        false,
+		},
+		{
+			name: "both omitted",
+			foo: Foo{
+				IgnoreMe:     "i'm a secret",
+				ChangeMyName: "i'm an alias",
+				OmitIfEmpty:  "",
+				Full:         "",
+			},
+			omitIfEmptyOmitted: true,
+			fullOmitted:        true,
+		},
+		{
+			name:               "zero",
+			foo:                Foo{},
+			omitIfEmptyOmitted: true,
+			fullOmitted:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			output := new(bytes.Buffer)
+			pp := New()
+			pp.SetOutput(output)
+
+			pp.Print(tc.foo)
+
+			result := output.String()
+
+			if strings.Contains(result, "IgnoreMe") {
+				t.Error("result should not contain IgnoreMe")
+			}
+
+			if strings.Contains(result, "OmitIfEmpty") && tc.omitIfEmptyOmitted {
+				t.Error("result should not contain OmitIfEmpty")
+			} else if !strings.Contains(result, "OmitIfEmpty") && !tc.omitIfEmptyOmitted {
+				t.Error("result should contain OmitIfEmpty")
+			}
+
+			// field Full is renamed to full by the tag
+			if strings.Contains(result, "full") && tc.fullOmitted {
+				t.Error("result should not contain full")
+			} else if !strings.Contains(result, "full") && !tc.fullOmitted {
+				t.Error("result should contain full")
+			}
+		})
+	}
+
 }

--- a/printer.go
+++ b/printer.go
@@ -3,6 +3,7 @@ package pp
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -208,7 +209,7 @@ func (p *printer) printStruct() {
 			var fieldName string
 			if tag := field.Tag.Get("pp"); tag != "" {
 				parts := strings.Split(tag, ",")
-				if len(parts) == 2 && parts[1] == "omitempty" && value.IsZero() {
+				if len(parts) == 2 && parts[1] == "omitempty" && valueIsZero(value) {
 					// omit field
 					continue
 				}
@@ -433,4 +434,47 @@ func (p *printer) format(object interface{}) string {
 
 func (p *printer) indent() string {
 	return strings.Repeat("\t", p.depth)
+}
+
+// valueIsZero reports whether v is the zero value for its type.
+// It returns false if the argument is invalid.
+// This is a copy paste of reflect#IsZero from go1.15. It is not present before go1.13 (source: https://golang.org/doc/go1.13#library)
+// 	source: https://golang.org/src/reflect/value.go?s=34297:34325#L1090
+// This will need to be updated for new types or the decision should be made to drop support for Go version pre go1.13
+func valueIsZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return math.Float64bits(v.Float()) == 0
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !valueIsZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return v.IsNil()
+	case reflect.String:
+		return v.Len() == 0
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !valueIsZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		// this is the only difference between stdlib reflect#IsZero and this function. We're not going to
+		// panic on the default cause, even
+		return false
+	}
 }


### PR DESCRIPTION
Add Struct Tag Support for printing structs. This allows the use of `-` to omit fields, `omitempty` to omit if empty, as well as specifying a different name to be printed as the field name.

This closes #42 but uses `-` instead of `noprint` as that is the standard tag for omitting fields as seen with JSON and YAML as well.

I added tests as well to provide 100% coverage for the code change.
---

With the following struct definition
```golang
type Foo struct {
    IgnoreMe     interface{} `pp:"-"`
    ChangeMyName string      `pp:"NewName"`
    OmitIfEmpty  string      `pp:",omitempty"`
    Full         string      `pp:"full,omitempty"`
}
```
Here are some examples of outputs
```golang
Foo{
    IgnoreMe:     "i'm a secret",
    ChangeMyName: "i'm an alias",
    OmitIfEmpty:  "i'm not empty", 
    Full:         "hello",
}
```
```
pp.Foo{
    NewName:     "i'm an alias",
    OmitIfEmpty: "i'm not empty",
    full:        "hello",
}
```
---
```golang
Foo{
    IgnoreMe:     "i'm a secret",
    ChangeMyName: "i'm an alias",
    OmitIfEmpty:  "",
    Full:         "hello",
}
```
```
pp.Foo{
    NewName: "i'm an alias",
    full:    "hello",
}
```
---
```golang
Foo{
    IgnoreMe:     "i'm a secret",
    ChangeMyName: "i'm an alias",
    OmitIfEmpty:  "",
    Full:         "",
}
```
```
pp.Foo{
    NewName: "i'm an alias",
}
```
---
```golang
Foo{}
```
```
pp.Foo{
    NewName: "",
}
```