### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pp.Fprintf()
 // ...
 ```
 
-You can also create own instances that do not interfer with the default printer
+You can also create own instances that do not interfere with the default printer:
+
 ```go
 mypp := pp.New()
 mypp.SetOutput(os.Stderr)


### PR DESCRIPTION
```diff
-You can also create own instances that do not interfer with the default printer
+You can also create own instances that do not interfere with the default printer:
```
+ newline