### PR TITLE
Add Badge for pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ mypp.Println()
 // ...
 ```
 
-API doc is available at: http://godoc.org/github.com/k0kubun/pp
-
 ### Custom colors
 
 If you require, you may change the colors (all or some) for syntax highlighting:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pp [![Go](https://github.com/k0kubun/pp/workflows/Go/badge.svg)](https://github.com/k0kubun/pp/actions)
+# pp [![Go](https://github.com/k0kubun/pp/workflows/Go/badge.svg)](https://github.com/k0kubun/pp/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/k0kubun/pp/v3.svg)](https://pkg.go.dev/github.com/k0kubun/pp/v3)
 
 Colored pretty printer for Go language
 


### PR DESCRIPTION
API doc says `Documentation not displayed due to license restrictions.`.
