### PR TITLE
build: upgrade `go` directive in `go.mod` to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
 module github.com/k0kubun/pp/v3
 
-go 1.14
+go 1.17
 
 require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88
 	github.com/mattn/go-colorable v0.1.7
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
+)
+
+require (
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
 )


### PR DESCRIPTION
This PR upgrades the `go` directive in `go.mod` file by running `go mod tidy -go=1.17` to enable [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading) supported by Go 1.17 or higher.

**Note 1:** This does not prevent users with earlier Go versions from successfully building packages from this module.

**Note 2:** The additional `require` directive is used to record indirect dependencies by Go 1.17 or higher, see https://go.dev/ref/mod#go-mod-file-go.