### PR TITLE
Implement SetOmitEmpty()

### DIFF
--- a/pp.go
+++ b/pp.go
@@ -49,6 +49,9 @@ type PrettyPrinter struct {
 	thousandsSeparator bool
 	// This skips unexported fields of structs.
 	exportedOnly bool
+
+	// This skips empty fields of structs.
+	omitEmpty bool
 }
 
 // New creates a new PrettyPrinter that can be used to pretty print values
@@ -66,6 +69,7 @@ func newPrettyPrinter(callerLevel int) *PrettyPrinter {
 		coloringEnabled: true,
 		decimalUint:     true,
 		exportedOnly:    false,
+		omitEmpty:       false,
 	}
 }
 
@@ -147,6 +151,11 @@ func (pp *PrettyPrinter) SetDecimalUint(enabled bool) {
 
 func (pp *PrettyPrinter) SetExportedOnly(enabled bool) {
 	pp.exportedOnly = enabled
+}
+
+// SetOmitEmpty makes empty fields in struct not be printed.
+func (pp *PrettyPrinter) SetOmitEmpty(enabled bool) {
+	pp.omitEmpty = enabled
 }
 
 func (pp *PrettyPrinter) SetThousandsSeparator(enabled bool) {

--- a/pp_test.go
+++ b/pp_test.go
@@ -160,3 +160,66 @@ func TestStructPrintingWithTags(t *testing.T) {
 	}
 
 }
+
+func TestStructPrintingWithOmitEmpty(t *testing.T) {
+	type Bar struct{ StringField string }
+	type Foo struct {
+		StringField string
+		StringPtr   *string
+
+		StructField    Bar
+		StructPtr      *Bar
+		InterfactField interface{}
+	}
+
+	stringVal := "foo"
+
+	testCases := []struct {
+		name               string
+		foo                Foo
+		omitIfEmptyOmitted bool
+		fullOmitted        bool
+		want               string
+	}{
+		{
+			name: "all set",
+			foo: Foo{
+				StringField: "foo",
+				StringPtr:   &stringVal,
+				StructField: Bar{
+					StringField: "baz",
+				},
+				StructPtr: &Bar{
+					StringField: "foobar",
+				},
+				InterfactField: &Bar{StringField: "fizzbuzz"},
+			},
+			want: "pp.Foo{\n  StringField: \"foo\",\n  StringPtr:   &\"foo\",\n  StructField: pp.Bar{\n    StringField: \"baz\",\n  },\n  StructPtr: &pp.Bar{\n    StringField: \"foobar\",\n  },\n  InterfactField: &pp.Bar{\n    StringField: \"fizzbuzz\",\n  },\n}",
+		},
+		{
+			name: "zero",
+			foo:  Foo{},
+			want: "pp.Foo{}",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			output := new(bytes.Buffer)
+			pp := New()
+			pp.SetOutput(output)
+			pp.SetColoringEnabled(false)
+			pp.SetOmitEmpty(true)
+
+			pp.Print(tc.foo)
+
+			result := output.String()
+
+			if result != tc.want {
+				t.Errorf("result differ, want: %q, got: %q", tc.want, result)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This PR implements `(*PrettyPrinter).SetOmitEmpty(enabled bool)`.

- This feature was proposed but not implemented to avoid introducing new global configurations(https://github.com/k0kubun/pp/pull/30#issuecomment-474656742).
  - This issue was resolved by introducing local instances(https://github.com/k0kubun/pp/pull/33). It's time to introduce features.