### PR TITLE
Fix omitEmpty is not propagated

### DIFF
--- a/pp_test.go
+++ b/pp_test.go
@@ -162,7 +162,11 @@ func TestStructPrintingWithTags(t *testing.T) {
 }
 
 func TestStructPrintingWithOmitEmpty(t *testing.T) {
-	type Bar struct{ StringField string }
+	type Bar struct {
+		StringField string
+		IntField    int
+	}
+
 	type Foo struct {
 		StringField string
 		StringPtr   *string
@@ -182,7 +186,7 @@ func TestStructPrintingWithOmitEmpty(t *testing.T) {
 		want               string
 	}{
 		{
-			name: "all set",
+			name: "set",
 			foo: Foo{
 				StringField: "foo",
 				StringPtr:   &stringVal,

--- a/printer.go
+++ b/printer.go
@@ -477,7 +477,7 @@ func (p *printer) colorize(text string, color uint16) string {
 }
 
 func (p *printer) format(object interface{}) string {
-	pp := newPrinter(object, p.currentScheme, p.maxDepth, p.coloringEnabled, p.decimalUint, p.exportedOnly, p.thousandsSeparator, false)
+	pp := newPrinter(object, p.currentScheme, p.maxDepth, p.coloringEnabled, p.decimalUint, p.exportedOnly, p.thousandsSeparator, p.omitEmpty)
 	pp.depth = p.depth
 	pp.visited = p.visited
 	if value, ok := object.(reflect.Value); ok {


### PR DESCRIPTION
I've found `omitEmpty` (#89) is not propagated in `(*printer).format()`. It is a bug in nested struct with `SetOmitEmpty()`.